### PR TITLE
Use MySQL instead of sqllite docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN mkdir $app
 WORKDIR $app
 ADD . $app
 
+RUN cd $app
 RUN bundle update
 RUN bundle install --with production
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,7 +199,7 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.1.0)
-    uglifier (4.1.19)
+    uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
     virtus (1.0.5)
       axiom-types (~> 0.1)
@@ -230,4 +230,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/bin/start
+++ b/bin/start
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 
-echo "Starting testmine, visit: http://192.168.99.100:3002/ in your browser."
+echo " ";
+echo -n "Waiting for DB to start..."
 
+while ! mysqladmin ping -h"app-db" --silent; do
+    sleep 1
+    echo -n "."
+done
+echo "Starting testmine, visit: http://192.168.99.100:3002/ in your browser."
+bundle install
 bundle exec rake db:migrate
 bundle exec rails s

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,10 +4,12 @@
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem 'sqlite3'
 development:
-  adapter: sqlite3
-  database: db/development.sqlite3
-  pool: 5
-  timeout: 5000
+  adapter: mysql2
+  host: app-db
+  database: testmite
+  username: root
+  password: testmine
+  port: 3306
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,102 +14,102 @@
 ActiveRecord::Schema.define(version: 20160216102230) do
 
   create_table "results", force: :cascade do |t|
-    t.integer  "test_definition_id"
-    t.integer  "run_id"
-    t.integer  "parent_id"
-    t.integer  "value"
-    t.string   "status"
-    t.text     "output"
+    t.integer  "test_definition_id", limit: 4
+    t.integer  "run_id",             limit: 4
+    t.integer  "parent_id",          limit: 4
+    t.integer  "value",              limit: 4
+    t.string   "status",             limit: 255
+    t.text     "output",             limit: 65535
     t.datetime "started_at"
     t.datetime "finished_at"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "results", ["parent_id"], name: "index_results_on_parent_id"
-  add_index "results", ["run_id", "test_definition_id"], name: "index_results_on_run_id_and_test_definition_id"
-  add_index "results", ["run_id"], name: "index_results_on_run_id"
-  add_index "results", ["test_definition_id"], name: "index_results_on_test_definition_id"
+  add_index "results", ["parent_id"], name: "index_results_on_parent_id", using: :btree
+  add_index "results", ["run_id", "test_definition_id"], name: "index_results_on_run_id_and_test_definition_id", using: :btree
+  add_index "results", ["run_id"], name: "index_results_on_run_id", using: :btree
+  add_index "results", ["test_definition_id"], name: "index_results_on_test_definition_id", using: :btree
 
   create_table "runs", force: :cascade do |t|
-    t.integer  "world_id"
-    t.string   "owner"
-    t.integer  "hive_job_id"
-    t.string   "target"
-    t.string   "status"
+    t.integer  "world_id",    limit: 4
+    t.string   "owner",       limit: 255
+    t.integer  "hive_job_id", limit: 4
+    t.string   "target",      limit: 255
+    t.string   "status",      limit: 255
     t.datetime "started_at"
     t.datetime "finished_at"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "runs", ["hive_job_id"], name: "index_runs_on_hive_job_id"
-  add_index "runs", ["target"], name: "index_runs_on_target"
-  add_index "runs", ["world_id"], name: "index_runs_on_world_id"
+  add_index "runs", ["hive_job_id"], name: "index_runs_on_hive_job_id", using: :btree
+  add_index "runs", ["target"], name: "index_runs_on_target", using: :btree
+  add_index "runs", ["world_id"], name: "index_runs_on_world_id", using: :btree
 
   create_table "suites", force: :cascade do |t|
-    t.string   "project"
-    t.string   "name"
-    t.string   "runner"
-    t.string   "description"
-    t.text     "documentation"
-    t.string   "url"
-    t.string   "repo"
+    t.string   "project",       limit: 255
+    t.string   "name",          limit: 255
+    t.string   "runner",        limit: 255
+    t.string   "description",   limit: 255
+    t.text     "documentation", limit: 65535
+    t.string   "url",           limit: 255
+    t.string   "repo",          limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "suites", ["project", "name"], name: "index_suites_on_project_and_name"
+  add_index "suites", ["project", "name"], name: "index_suites_on_project_and_name", using: :btree
 
   create_table "taggings", force: :cascade do |t|
-    t.integer  "tag_id"
-    t.integer  "taggable_id"
-    t.string   "taggable_type"
-    t.integer  "tagger_id"
-    t.string   "tagger_type"
+    t.integer  "tag_id",        limit: 4
+    t.integer  "taggable_id",   limit: 4
+    t.string   "taggable_type", limit: 255
+    t.integer  "tagger_id",     limit: 4
+    t.string   "tagger_type",   limit: 255
     t.string   "context",       limit: 128
     t.datetime "created_at"
   end
 
-  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
-  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
+  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
 
   create_table "tags", force: :cascade do |t|
-    t.string  "name"
-    t.integer "taggings_count", default: 0
+    t.string  "name",           limit: 255
+    t.integer "taggings_count", limit: 4,   default: 0
   end
 
-  add_index "tags", ["name"], name: "index_tags_on_name", unique: true
+  add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
   create_table "test_definitions", force: :cascade do |t|
-    t.string   "name"
-    t.string   "node_type"
-    t.text     "description"
-    t.string   "file"
-    t.integer  "line"
-    t.integer  "parent_id"
-    t.integer  "suite_id"
+    t.string   "name",        limit: 255
+    t.string   "node_type",   limit: 255
+    t.text     "description", limit: 65535
+    t.string   "file",        limit: 255
+    t.integer  "line",        limit: 4
+    t.integer  "parent_id",   limit: 4
+    t.integer  "suite_id",    limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "test_definitions", ["name", "suite_id", "file", "parent_id"], name: "lookup"
-  add_index "test_definitions", ["parent_id"], name: "index_test_definitions_on_parent_id"
-  add_index "test_definitions", ["suite_id"], name: "index_test_definitions_on_suite_id"
+  add_index "test_definitions", ["name", "suite_id", "file", "parent_id"], name: "lookup", using: :btree
+  add_index "test_definitions", ["parent_id"], name: "index_test_definitions_on_parent_id", using: :btree
+  add_index "test_definitions", ["suite_id"], name: "index_test_definitions_on_suite_id", using: :btree
 
   create_table "worlds", force: :cascade do |t|
-    t.string   "type"
-    t.string   "name"
-    t.text     "description"
-    t.string   "project"
-    t.string   "component"
-    t.string   "version"
+    t.string   "type",        limit: 255
+    t.string   "name",        limit: 255
+    t.text     "description", limit: 65535
+    t.string   "project",     limit: 255
+    t.string   "component",   limit: 255
+    t.string   "version",     limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "worlds", ["project", "component", "version"], name: "index_worlds_on_project_and_component_and_version"
-  add_index "worlds", ["project", "component"], name: "index_worlds_on_project_and_component"
-  add_index "worlds", ["project"], name: "index_worlds_on_project"
+  add_index "worlds", ["project", "component", "version"], name: "index_worlds_on_project_and_component_and_version", using: :btree
+  add_index "worlds", ["project", "component"], name: "index_worlds_on_project_and_component", using: :btree
+  add_index "worlds", ["project"], name: "index_worlds_on_project", using: :btree
 
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,16 @@
 version: '3'
 services:
+  app-db:
+    image: mysql:5.7
+    restart: always
+    volumes:
+      - db_data:/var/lib/mysql
+      - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: testmine
+      MYSQL_DATABASE: testmite
   testmine:
     build: .
     working_dir: /app
@@ -8,3 +19,7 @@ services:
     command: 'bin/start'
     ports:
       - "3002:3002"
+    links:
+      - app-db
+volumes:
+  db_data:

--- a/docker/docker-entrypoint-initdb.d/01-testmite_structure.sql
+++ b/docker/docker-entrypoint-initdb.d/01-testmite_structure.sql
@@ -1,0 +1,205 @@
+-- MySQL dump 10.14  Distrib 5.5.60-MariaDB, for Linux (x86_64)
+--
+-- Host: app-db    Database: testmite
+-- ------------------------------------------------------
+-- Server version	5.7.24
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Create the database `testmite`
+--
+
+CREATE DATABASE testmite;
+USE testmite;
+
+--
+-- Table structure for table `results`
+--
+
+DROP TABLE IF EXISTS `results`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `results` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `test_definition_id` int(11) DEFAULT NULL,
+  `run_id` int(11) DEFAULT NULL,
+  `parent_id` int(11) DEFAULT NULL,
+  `value` int(11) DEFAULT NULL,
+  `status` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `output` text COLLATE utf8_unicode_ci,
+  `started_at` datetime DEFAULT NULL,
+  `finished_at` datetime DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_results_on_parent_id` (`parent_id`),
+  KEY `index_results_on_run_id` (`run_id`),
+  KEY `index_results_on_run_id_and_test_definition_id` (`run_id`,`test_definition_id`),
+  KEY `index_results_on_test_definition_id` (`test_definition_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=18595903 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `runs`
+--
+
+DROP TABLE IF EXISTS `runs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `runs` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `world_id` int(11) DEFAULT NULL,
+  `owner` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `hive_job_id` int(11) DEFAULT NULL,
+  `target` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `status` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `started_at` datetime DEFAULT NULL,
+  `finished_at` datetime DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_runs_on_world_id` (`world_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=411184 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `schema_migrations`
+--
+
+DROP TABLE IF EXISTS `schema_migrations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `schema_migrations` (
+  `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  UNIQUE KEY `unique_schema_migrations` (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `suites`
+--
+
+DROP TABLE IF EXISTS `suites`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `suites` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `project` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `runner` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `description` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `documentation` text COLLATE utf8_unicode_ci,
+  `url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `repo` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_suites_on_project_and_name` (`project`,`name`)
+) ENGINE=InnoDB AUTO_INCREMENT=50 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `taggings`
+--
+
+DROP TABLE IF EXISTS `taggings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `taggings` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `tag_id` int(11) DEFAULT NULL,
+  `taggable_id` int(11) DEFAULT NULL,
+  `taggable_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `tagger_id` int(11) DEFAULT NULL,
+  `tagger_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `context` varchar(128) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `taggings_idx` (`tag_id`,`taggable_id`,`taggable_type`,`context`,`tagger_id`,`tagger_type`),
+  KEY `index_taggings_on_taggable_id_and_taggable_type_and_context` (`taggable_id`,`taggable_type`,`context`)
+) ENGINE=InnoDB AUTO_INCREMENT=2018927 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `tags`
+--
+
+DROP TABLE IF EXISTS `tags`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `tags` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `taggings_count` int(11) DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `index_tags_on_name` (`name`)
+) ENGINE=InnoDB AUTO_INCREMENT=196 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `test_definitions`
+--
+
+DROP TABLE IF EXISTS `test_definitions`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `test_definitions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `node_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `description` text COLLATE utf8_unicode_ci,
+  `file` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `line` int(11) DEFAULT NULL,
+  `parent_id` int(11) DEFAULT NULL,
+  `suite_id` int(11) DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `lookup` (`name`,`suite_id`,`file`,`parent_id`),
+  KEY `index_test_definitions_on_suite_id` (`suite_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=28045 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `worlds`
+--
+
+DROP TABLE IF EXISTS `worlds`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `worlds` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `description` text COLLATE utf8_unicode_ci,
+  `project` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `component` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `version` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_worlds_on_project_and_component` (`project`,`component`),
+  KEY `index_worlds_on_project_and_component_and_version` (`project`,`component`,`version`)
+) ENGINE=InnoDB AUTO_INCREMENT=19839 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2018-11-29 11:21:43


### PR DESCRIPTION
sqllite is slow and cannot support large database. It is also an unreal
representation of what we are using on the servers in AWS.

This commit updates docker images to use MySQL db with basic testmine
schema.